### PR TITLE
FB issue fix

### DIFF
--- a/Auth0/WebBrowserAuthenticator.cs
+++ b/Auth0/WebBrowserAuthenticator.cs
@@ -16,6 +16,12 @@ public class WebBrowserAuthenticator : IdentityModel.OidcClient.Browser.IBrowser
       var url = new RequestUrl(options.EndUrl)
           .Create(new Parameters(result.Properties));
 
+      // Workaround for Facebook's issue (https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url)
+      if (url.EndsWith("%23_%3D_"))
+      {
+        url = url.Substring(0, url.LastIndexOf("%23_%3D_"));
+      }
+
       return new BrowserResult
       {
         Response = url,


### PR DESCRIPTION
This PR fixes an issue when Facebook is used as an Identity provider (see [this](https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url) and [this](https://community.auth0.com/t/facebook-login-fails-with-invalid-state-error/112930))